### PR TITLE
Make alternative runtimes available

### DIFF
--- a/cmd/cri/options/options.go
+++ b/cmd/cri/options/options.go
@@ -120,6 +120,7 @@ func NewContainerRuntimeOptions() *config.ContainerRuntimeOptions {
 		PodSandboxImage:           defaultPodSandboxImage,
 		ImagePullProgressDeadline: metav1.Duration{Duration: 1 * time.Minute},
 		NetworkPluginName:         "cni",
+		RuntimeHandler:            []string{},
 
 		CNIBinDir:   cniBinDir,
 		CNIConfDir:  cniConfDir,

--- a/config/options.go
+++ b/config/options.go
@@ -83,6 +83,8 @@ type ContainerRuntimeOptions struct {
 	// HairpinMode is the mode used to allow endpoints of a Service to load
 	// balance back to themselves if they should try to access their own Service
 	HairpinMode HairpinMode
+	// RuntimeHandler is a slice of runtime handler mappings e.g. runc=iocontainerd.runc.v2
+	RuntimeHandler []string
 }
 
 // AddFlags has the set of flags needed by cri-dockerd
@@ -138,6 +140,13 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 		fmt.Sprintf(
 			"The address to bind the CRI streaming server to. If not specified, it will bind to all addresses.",
 		),
+	)
+
+	fs.StringSliceVar(
+		&s.RuntimeHandler,
+		"runtime-handler",
+		s.RuntimeHandler,
+		"Additional runtimes e.g. runc=io.containerd.runc.v2",
 	)
 	// Network plugin settings for Docker.
 	fs.StringVar(

--- a/core/container_create.go
+++ b/core/container_create.go
@@ -65,6 +65,7 @@ func (ds *dockerService) CreateContainer(
 	}
 	containerName := makeContainerName(sandboxConfig, config)
 	terminationMessagePath, _ := config.Annotations["io.kubernetes.container.terminationMessagePath"]
+	json, _, err := ds.getPodSandboxDetails(podSandboxID)
 	createConfig := types.ContainerCreateConfig{
 		Name: containerName,
 		Config: &container.Config{
@@ -89,6 +90,7 @@ func (ds *dockerService) CreateContainer(
 			RestartPolicy: container.RestartPolicy{
 				Name: "no",
 			},
+			Runtime: json.Config.Labels[runtimeLabelName],
 		},
 	}
 

--- a/core/docker_service.go
+++ b/core/docker_service.go
@@ -123,6 +123,7 @@ var internalLabelKeys = []string{containerTypeLabelKey, containerLogPathLabelKey
 func NewDockerService(
 	clientConfig *config.ClientConfig,
 	podSandboxImage string,
+	runtimeHandler map[string]string,
 	streamingConfig *streaming.Config,
 	pluginSettings *config.NetworkPluginSettings,
 	cgroupsName string,
@@ -145,6 +146,7 @@ func NewDockerService(
 		client:          c,
 		os:              config.RealOS{},
 		podSandboxImage: podSandboxImage,
+		runtimeHandler:  runtimeHandler,
 		streamingRuntime: &streaming.StreamingRuntime{
 			Client:      client,
 			ExecHandler: &NativeExecHandler{},
@@ -256,6 +258,7 @@ type dockerService struct {
 	client           libdocker.DockerClientInterface
 	os               config.OSInterface
 	podSandboxImage  string
+	runtimeHandler   map[string]string
 	streamingRuntime *streaming.StreamingRuntime
 	streamingServer  streaming.Server
 


### PR DESCRIPTION
This change let cri-dockerd pass the runtime class from Kubernetes to dockerd.

The runtime class is provided as name like "spin" but dockerd expects it as "io.containerd.spin.v1". To map this values they need to be provided during startup as flags:
`cri-dockerd --runtime-handler spin=io.containerd.spin.v1,wasmedge=io.containerd.wasmedge.v1`